### PR TITLE
Dependencies updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,9 @@ repositories {
 
 dependencies {
     compile platform('software.amazon.awssdk:bom:2.13.10')
-    compile 'software.amazon.awssdk:secretsmanager'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    api 'software.amazon.awssdk:secretsmanager'
+    implementation 'software.amazon.awssdk:sts'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     compileOnly 'org.projectlombok:lombok:1.18.12'
     annotationProcessor 'org.projectlombok:lombok:1.18.12'
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     ext {
-        versionnum = project.hasProperty('versionnum') ? project.property('versionnum') : '1.1.0-PREVIEW'
+        versionnum = project.hasProperty('versionnum') ? project.property('versionnum') : '1.1.1-PREVIEW'
         groupid = project.hasProperty('groupid') ? project.property('groupid') : 'com.github.bancolombia'
         artifactid = group = project.hasProperty('artifactid') ? project.property('artifactid') : 'secrets-manager'
     }


### PR DESCRIPTION
New dependency added: amazon STS module for enable WebIdentityTokenFileCredentialsProvider in the custom CredentialProviderChain

Amazon's Secrets Manager dependency is loaded as api instead compile strategy to expose transitively to consumers