### PR TITLE
The builder used to set the region is changed to the input and output…

### DIFF
--- a/sync/aws-secrets-manager-sync/src/main/java/co/com/bancolombia/secretsmanager/connector/AWSSecretManagerConnector.java
+++ b/sync/aws-secrets-manager-sync/src/main/java/co/com/bancolombia/secretsmanager/connector/AWSSecretManagerConnector.java
@@ -95,8 +95,7 @@ public class AWSSecretManagerConnector implements GenericManager {
     }
 
     private SecretsManagerClient buildClient(SecretsManagerClientBuilder builder, String region, Optional<URI> endpoint) {
-        SecretsManagerClient.builder()
-                .credentialsProvider(getProviderChain())
+        builder.credentialsProvider(getProviderChain())
                 .region(Region.of(region));
         endpoint.ifPresent(builder::endpointOverride);
         return builder.build();


### PR DESCRIPTION
The constructor of AWSSecretManagerConnector was producing an error caused by the region not being correctly set, since the method buildClient was setting the region and the provider chain in a new builder instead of the one returned.